### PR TITLE
Update languages

### DIFF
--- a/build/languages.toml
+++ b/build/languages.toml
@@ -237,8 +237,7 @@ helix_override = true
 [[languages]]
 name = "javascript"
 repo = "https://github.com/tree-sitter/tree-sitter-javascript"
-hash = "f1e5a09"
-helix_path = "_javascript"
+helix_override = true
 aliases = ["js"]
 
 # [[languages]]
@@ -463,10 +462,9 @@ hash = "342d9be"
 [[languages]]
 name = "typescript"
 repo = "https://github.com/tree-sitter/tree-sitter-typescript"
-hash = "b1bf482"
-helix_path = "_typescript"
 # Disgusting hack to extract the non-TSX grammar, relocate the scanner header and patch the source file appropriately
 # Words cannot describe how much I hate this, but it works
+helix_override = true
 command = '''
 set -euxo pipefail &&
 cp languages/temp/typescript/common/scanner.h languages/temp/typescript/typescript/src &&

--- a/build/languages.toml
+++ b/build/languages.toml
@@ -237,6 +237,7 @@ helix_override = true
 [[languages]]
 name = "javascript"
 repo = "https://github.com/tree-sitter/tree-sitter-javascript"
+hash = "f1e5a09"
 helix_override = true
 aliases = ["js"]
 
@@ -462,6 +463,7 @@ hash = "342d9be"
 [[languages]]
 name = "typescript"
 repo = "https://github.com/tree-sitter/tree-sitter-typescript"
+hash = "d847898"
 # Disgusting hack to extract the non-TSX grammar, relocate the scanner header and patch the source file appropriately
 # Words cannot describe how much I hate this, but it works
 helix_override = true

--- a/languages/haskell/queries/highlights.scm
+++ b/languages/haskell/queries/highlights.scm
@@ -33,6 +33,11 @@
 ;; ----------------------------------------------------------------------------
 ;; Keywords, operators, includes
 
+[
+  "forall"
+  "∀"
+] @keyword.control.repeat
+
 (pragma) @constant.macro
 
 [
@@ -68,10 +73,7 @@
   "@"
 ] @operator
 
-(qualified_module (module) @constructor)
-(qualified_type (module) @namespace)
-(qualified_variable (module) @namespace)
-(import (module) @namespace)
+(module) @namespace
 
 [
   (where)
@@ -92,8 +94,6 @@
   "do"
   "mdo"
   "rec"
-  "forall"
-  "∀"
   "infix"
   "infixl"
   "infixr"
@@ -104,22 +104,35 @@
 ;; Functions and variables
 
 (signature name: (variable) @type)
-(function name: (variable) @function)
-
-(variable) @variable
-"_" @variable.builtin
+(function
+  name: (variable) @function
+  patterns: (patterns))
+((signature (fun)) . (function (variable) @function))
+((signature (context (fun))) . (function (variable) @function))
+((signature (forall (context (fun)))) . (function (variable) @function))
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators
 
-("@" @namespace)  ; "as" pattern operator, e.g. x@Constructor
+(exp_infix (exp_name) @function)
+(exp_apply . (exp_name (variable) @function))
+(exp_apply . (exp_name (qualified_variable (variable) @function)))
 
+(variable) @variable
+(pat_wildcard) @variable
 
 ;; ----------------------------------------------------------------------------
 ;; Types
 
 (type) @type
+(type_variable) @type
 
 (constructor) @constructor
 
 ; True or False
 ((constructor) @_bool (#match? @_bool "(True|False)")) @constant.builtin.boolean
+
+;; ----------------------------------------------------------------------------
+;; Quasi-quotes
+
+(quoter) @function
+; Highlighting of quasiquote_body is handled by injections.scm

--- a/languages/javascript/queries/highlights-jsx.scm
+++ b/languages/javascript/queries/highlights-jsx.scm
@@ -1,0 +1,8 @@
+(jsx_opening_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
+(jsx_closing_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
+(jsx_self_closing_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
+
+(jsx_attribute (property_identifier) @attribute)
+(jsx_opening_element (["<" ">"]) @punctuation.bracket)
+(jsx_closing_element (["</" ">"]) @punctuation.bracket)
+(jsx_self_closing_element (["<" "/>"]) @punctuation.bracket)

--- a/languages/javascript/queries/highlights-params.scm
+++ b/languages/javascript/queries/highlights-params.scm
@@ -1,0 +1,12 @@
+(formal_parameters
+  [
+    (identifier) @variable.parameter
+    (array_pattern
+      (identifier) @variable.parameter)
+    (object_pattern
+      [
+        (pair_pattern value: (identifier) @variable.parameter)
+        (shorthand_property_identifier_pattern) @variable.parameter
+      ])
+  ]
+)

--- a/languages/javascript/queries/highlights.scm
+++ b/languages/javascript/queries/highlights.scm
@@ -1,36 +1,205 @@
-; Function and method parameters
-;-------------------------------
+; Special identifiers
+;--------------------
 
-; Javascript and Typescript Treesitter grammars deviate when defining the
-; tree structure for parameters, so we need to address them in each specific
-; language instead of ecma.
+([
+    (identifier)
+    (shorthand_property_identifier)
+    (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
 
-; (p)
-(formal_parameters 
-  (identifier) @variable.parameter)
 
-; (...p)
-(formal_parameters
-  (rest_pattern
-    (identifier) @variable.parameter))
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
 
-; ({ p })
-(formal_parameters
-  (object_pattern
-    (shorthand_property_identifier_pattern) @variable.parameter))
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+ (#is-not? local))
 
-; ({ a: p })
-(formal_parameters
-  (object_pattern
-    (pair_pattern
-      value: (identifier) @variable.parameter)))
+((identifier) @function.builtin
+ (#eq? @function.builtin "require")
+ (#is-not? local))
 
-; ([ p ])
-(formal_parameters
-  (array_pattern
-    (identifier) @variable.parameter))
+; Function and method definitions
+;--------------------------------
 
-; (p = 1)
-(formal_parameters
-  (assignment_pattern
-    left: (identifier) @variable.parameter))
+(function
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function) (arrow_function)])
+
+; Function and method calls
+;--------------------------
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Variables
+;----------
+
+(identifier) @variable
+
+; Properties
+;-----------
+
+(property_identifier) @property
+
+; Literals
+;---------
+
+(this) @variable.builtin
+(super) @variable.builtin
+
+[
+  (true)
+  (false)
+  (null)
+  (undefined)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+] @string
+
+(regex) @string.special
+(number) @number
+
+; Tokens
+;-------
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  ";"
+  (optional_chain)
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+[
+  "as"
+  "async"
+  "await"
+  "break"
+  "case"
+  "catch"
+  "class"
+  "const"
+  "continue"
+  "debugger"
+  "default"
+  "delete"
+  "do"
+  "else"
+  "export"
+  "extends"
+  "finally"
+  "for"
+  "from"
+  "function"
+  "get"
+  "if"
+  "import"
+  "in"
+  "instanceof"
+  "let"
+  "new"
+  "of"
+  "return"
+  "set"
+  "static"
+  "switch"
+  "target"
+  "throw"
+  "try"
+  "typeof"
+  "var"
+  "void"
+  "while"
+  "with"
+  "yield"
+] @keyword

--- a/languages/javascript/queries/injections.scm
+++ b/languages/javascript/queries/injections.scm
@@ -1,0 +1,32 @@
+; Parse the contents of tagged template literals using
+; a language inferred from the tag.
+
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; Parse regex syntax within regex literals
+
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
+
+ ; Parse JSDoc annotations in comments
+
+((comment) @injection.content
+ (#set! injection.language "jsdoc"))
+
+; Parse Ember/Glimmer/Handlebars/HTMLBars/etc. template literals
+; e.g.: await render(hbs`<SomeComponent />`)
+(call_expression
+  function: ((identifier) @_name
+             (#eq? @_name "hbs"))
+  arguments: ((template_string) @glimmer
+              (#offset! @glimmer 0 1 0 -1)))
+
+; Ember Unified <template> syntax
+; e.g.: <template><SomeComponent @arg={{double @value}} /></template>
+((glimmer_template) @glimmer)

--- a/languages/javascript/queries/locals.scm
+++ b/languages/javascript/queries/locals.scm
@@ -1,14 +1,23 @@
+; Scopes
+;-------
+
+[
+  (statement_block)
+  (function)
+  (arrow_function)
+  (function_declaration)
+  (method_definition)
+] @local.scope
+
 ; Definitions
 ;------------
-; Javascript and Typescript Treesitter grammars deviate when defining the
-; tree structure for parameters, so we need to address them in each specific
-; language instead of ecma.
 
-; (i)
-(formal_parameters 
-  (identifier) @local.definition)
+(pattern/identifier)@local.definition
 
-; (i = 1)
-(formal_parameters 
-  (assignment_pattern
-    left: (identifier) @local.definition))
+(variable_declarator
+  name: (identifier) @local.definition)
+
+; References
+;------------
+
+(identifier) @local.reference

--- a/languages/javascript/queries/tags.scm
+++ b/languages/javascript/queries/tags.scm
@@ -86,3 +86,14 @@
 
 (new_expression
   constructor: (_) @name) @reference.class
+
+(export_statement value: (assignment_expression left: (identifier) @name right: ([
+ (number)
+ (string)
+ (identifier)
+ (undefined)
+ (null)
+ (new_expression)
+ (binary_expression)
+ (call_expression)
+]))) @definition.constant

--- a/languages/typescript/queries/highlights.scm
+++ b/languages/typescript/queries/highlights.scm
@@ -1,140 +1,35 @@
-; Namespaces
-; ----------
-
-(internal_module
-  [((identifier) @namespace) ((nested_identifier (identifier) @namespace))])
-
-(ambient_declaration "global" @namespace)
-
-; Parameters
-; ----------
-; Javascript and Typescript Treesitter grammars deviate when defining the
-; tree structure for parameters, so we need to address them in each specific
-; language instead of ecma.
-
-; (p: t)
-; (p: t = 1)
-(required_parameter 
-  (identifier) @variable.parameter)
-
-; (...p: t)
-(required_parameter
-  (rest_pattern
-    (identifier) @variable.parameter))
-
-; ({ p }: { p: t })
-(required_parameter
-  (object_pattern
-    (shorthand_property_identifier_pattern) @variable.parameter))
-
-; ({ a: p }: { a: t })
-(required_parameter
-  (object_pattern
-    (pair_pattern
-      value: (identifier) @variable.parameter)))
-
-; ([ p ]: t[])
-(required_parameter
-  (array_pattern
-    (identifier) @variable.parameter))
-
-; (p?: t)
-; (p?: t = 1) // Invalid but still posible to hihglight.
-(optional_parameter 
-  (identifier) @variable.parameter)
-
-; (...p?: t) // Invalid but still posible to hihglight.
-(optional_parameter
-  (rest_pattern
-    (identifier) @variable.parameter))
-
-; ({ p }: { p?: t})
-(optional_parameter
-  (object_pattern
-    (shorthand_property_identifier_pattern) @variable.parameter))
-
-; ({ a: p }: { a?: t })
-(optional_parameter
-  (object_pattern
-    (pair_pattern
-      value: (identifier) @variable.parameter)))
-
-; ([ p ]?: t[]) // Invalid but still posible to hihglight.
-(optional_parameter
-  (array_pattern
-    (identifier) @variable.parameter))
-
-; Punctuation
-; -----------
-
-[
-  ":"
-] @punctuation.delimiter
-
-(optional_parameter "?" @punctuation.special)
-(property_signature "?" @punctuation.special)
-
-(conditional_type ["?" ":"] @operator)
-
-; Keywords
-; --------
-
-[
-  "abstract"
-  "declare"
-  "export"
-  "infer"
-  "implements"
-  "keyof"
-  "namespace"
-  "override"
-  "satisfies"
-] @keyword
-
-[
-  "type"
-  "interface"
-  "enum"
-] @keyword.storage.type
-
-[
-  "public"
-  "private"
-  "protected"
-  "readonly"
-] @keyword.storage.modifier
-
 ; Types
-; -----
 
 (type_identifier) @type
 (predefined_type) @type.builtin
 
-; Type arguments and parameters
-; -----------------------------
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 
 (type_arguments
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
 
-(type_parameters
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
+; Variables
 
-; Literals
-; --------
+(required_parameter (identifier) @variable.parameter)
+(optional_parameter (identifier) @variable.parameter)
 
-[
-  (template_literal_type)
-] @string
+; Keywords
 
-; Tokens
-; ------
-
-(template_type
-  "${" @punctuation.special
-  "}" @punctuation.special) @embedded
+[ "abstract"
+  "declare"
+  "enum"
+  "export"
+  "implements"
+  "interface"
+  "keyof"
+  "namespace"
+  "private"
+  "protected"
+  "public"
+  "type"
+  "readonly"
+  "override"
+  "satisfies"
+] @keyword

--- a/languages/typescript/queries/locals.scm
+++ b/languages/typescript/queries/locals.scm
@@ -1,16 +1,2 @@
-; Definitions
-;------------
-
-; Javascript and Typescript Treesitter grammars deviate when defining the
-; tree structure for parameters, so we need to address them in each specific
-; language instead of ecma.
-
-; (i: t)
-; (i: t = 1)
-(required_parameter
-  (identifier) @local.definition)
-
-; (i?: t)
-; (i?: t = 1) // Invalid but still posible to hihglight.
-(optional_parameter
-  (identifier) @local.definition)
+(required_parameter (identifier) @local.definition)
+(optional_parameter (identifier) @local.definition)

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -1793,7 +1793,9 @@ pub mod javascript {
     pub const HIGHLIGHT_QUERY: &str = include_str!(
         "../languages/javascript/queries/highlights.scm"
     );
-    pub const INJECTIONS_QUERY: &str = "";
+    pub const INJECTIONS_QUERY: &str = include_str!(
+        "../languages/javascript/queries/injections.scm"
+    );
     pub const LOCALS_QUERY: &str = include_str!(
         "../languages/javascript/queries/locals.scm"
     );


### PR DESCRIPTION
## Haskell

Just regular update.

## Javascript / Typescript

I noticed that both Javascript and Typescript were not highlighting correctly and seems like it's due to not loading the [ecma](https://github.com/helix-editor/helix/tree/master/runtime/queries/ecma) queries.

That's how it looks like loading only the private package: https://autumn-30n.pages.dev/javascript_onedark

And that's how it looks like loading the public package 👇🏻 
<img width="1247" alt="Screenshot 2023-10-23 at 11 20 04 AM" src="https://github.com/Colonial-Dev/inkjet/assets/36407/d840205a-4eea-4e72-b1ba-2d9df797294a">
